### PR TITLE
added reference to arch installation instructions wiki page

### DIFF
--- a/installing_linux.md
+++ b/installing_linux.md
@@ -6,7 +6,7 @@ _TODO_
 
 ## Arch
 
-_TODO_
+{% include "git+https://github.com/ethereum/go-ethereum.wiki.git/Installation-Instructions-for-Arch.md" %}
 
 ## Debian/Ubuntu
 


### PR DESCRIPTION
Is simply adding the link enough?
wiki page: https://github.com/ethereum/go-ethereum/wiki/Installation-Instructions-for-Arch
